### PR TITLE
Feature/build head

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ this committed to the repository, we can start using `mbt` cli to build in
 several ways as shown below.
 
 ```
-# Build the current branch 
+# Build the current master branch 
 mbt build branch --in .
+
+# Build the current branch
+mbt build head --in .
 
 # Build a specific branch
 mbt build branch feature --in .

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"log"
 	"os"
 
 	"gopkg.in/sirupsen/logrus.v1"
@@ -34,13 +33,7 @@ Builds all modules as of the head of the branch that is in the specified folder.
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		branch, err := lib.GetWorkingBranchName(in)
-		if err != nil {
-			return handle(err)
-		}
-		log.Println("working branch", branch)
-
-		m, err := lib.ManifestByBranch(in, branch)
+		m, err := lib.ManifestByHead(in)
 		if err != nil {
 			return handle(err)
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"log"
 	"os"
 
 	"gopkg.in/sirupsen/logrus.v1"
@@ -20,7 +21,32 @@ func init() {
 	buildCommand.AddCommand(buildBranch)
 	buildCommand.AddCommand(buildPr)
 	buildCommand.AddCommand(buildDiff)
+	buildCommand.AddCommand(buildHead)
 	RootCmd.AddCommand(buildCommand)
+}
+
+var buildHead = &cobra.Command{
+	Use:   "head",
+	Short: "Builds the local directory",
+	Long: `Builds the local directory
+
+Builds all modules as of the head of the branch that is in the specified folder.
+
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		branch, err := lib.GetWorkingBranchName(in)
+		if err != nil {
+			return handle(err)
+		}
+		log.Println("working branch", branch)
+
+		m, err := lib.ManifestByBranch(in, branch)
+		if err != nil {
+			return handle(err)
+		}
+
+		return build(m)
+	},
 }
 
 var buildBranch = &cobra.Command{

--- a/lib/git_utils.go
+++ b/lib/git_utils.go
@@ -87,23 +87,11 @@ func getCommit(repo *git.Repository, commitSha string) (*git.Commit, error) {
 	return repo.LookupCommit(commitOid)
 }
 
-// GetWorkingBranchName will return the name of the branch in the working directory
-func GetWorkingBranchName(dir string) (string, error) {
-
-	repo, _, err := openRepo(dir)
-	if err != nil {
-		return "", wrap(err)
-	}
-
+func getBranchName(repo *git.Repository) (string, error) {
 	head, err := repo.Head()
 	if err != nil {
 		return "", wrap(err)
 	}
 
-	name, err := head.Branch().Name()
-	if err != nil {
-		return "", wrap(err)
-	}
-
-	return name, nil
+	return head.Branch().Name()
 }

--- a/lib/git_utils.go
+++ b/lib/git_utils.go
@@ -86,3 +86,24 @@ func getCommit(repo *git.Repository, commitSha string) (*git.Commit, error) {
 
 	return repo.LookupCommit(commitOid)
 }
+
+// GetWorkingBranchName will return the name of the branch in the working directory
+func GetWorkingBranchName(dir string) (string, error) {
+
+	repo, _, err := openRepo(dir)
+	if err != nil {
+		return "", wrap(err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", wrap(err)
+	}
+
+	name, err := head.Branch().Name()
+	if err != nil {
+		return "", wrap(err)
+	}
+
+	return name, nil
+}

--- a/lib/git_utils_test.go
+++ b/lib/git_utils_test.go
@@ -67,3 +67,18 @@ func TestInvalidBranch(t *testing.T) {
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "mbt: no reference found for shorthand 'foo'")
 }
+
+func TestBranchName(t *testing.T) {
+	clean()
+
+	repo, err := createTestRepository(".tmp/repo")
+	check(t, err)
+
+	check(t, repo.InitModule("app-a"))
+	check(t, repo.Commit("first"))
+	check(t, repo.SwitchToBranch("feature"))
+
+	branch, err := getBranchName(repo.Repo)
+
+	assert.Equal(t, "feature", branch)
+}

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -120,6 +120,25 @@ func ManifestByDiff(dir, from, to string) (*Manifest, error) {
 	return &Manifest{Modules: a, Dir: dir, Sha: to}, nil
 }
 
+// ManifestByHead returns the manifest for head of the current branch.
+func ManifestByHead(dir string) (*Manifest, error) {
+	repo, m, err := openRepo(dir)
+	if err != nil {
+		return nil, wrap(err)
+	}
+
+	if m != nil {
+		return m, nil
+	}
+
+	branch, err := getBranchName(repo)
+	if err != nil {
+		return nil, wrap(err)
+	}
+
+	return fromBranch(repo, dir, branch)
+}
+
 func (m *Manifest) indexByName() map[string]*Module {
 	return m.Modules.indexByName()
 }

--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestSingleModDir(t *testing.T) {
 	clean()
-	// defer clean()
 
 	repo, err := createTestRepository(".tmp/repo")
 	check(t, err)
@@ -252,6 +251,20 @@ func TestManifestByDiff(t *testing.T) {
 	check(t, err)
 
 	assert.Len(t, m.Modules, 0)
+}
+
+func TestManifestByHead(t *testing.T) {
+	repo, err := createTestRepository(".tmp/repo")
+	check(t, err)
+
+	check(t, repo.InitModule("app-a"))
+	check(t, repo.Commit("first"))
+	check(t, repo.SwitchToBranch("feature"))
+
+	m, err := ManifestByHead(".tmp/repo")
+	check(t, err)
+
+	assert.Equal(t, "app-a", m.Modules[0].Name())
 }
 
 func TestDependencyChange(t *testing.T) {


### PR DESCRIPTION
make a build option for building the head of the branch within the workspace. 

It still makes the assumption that all code is committed for the branch name to be populated, otherwise the branch will be marked as 'dirty' before the command is executed