### PR TITLE
Feature: Build/Describe content of a commit

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,6 +19,8 @@ func init() {
 
 	buildLocal.Flags().BoolVarP(&all, "all", "a", false, "all modules")
 
+	buildCommit.Flags().BoolVarP(&content, "content", "c", false, "build the modules impacted by the content of the commit")
+
 	buildCommand.AddCommand(buildBranch)
 	buildCommand.AddCommand(buildPr)
 	buildCommand.AddCommand(buildDiff)
@@ -115,6 +117,9 @@ var buildCommit = &cobra.Command{
 	Use:   "commit <sha>",
 	Short: "Build all modules in the specified commit",
 	Long: `Build all modules in the specified commit
+
+	If --content flag is specified, this command will build just the modules
+	impacted by the specified commit.
 	`,
 	RunE: buildHandler(func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -123,6 +128,9 @@ var buildCommit = &cobra.Command{
 
 		commit := args[0]
 
+		if content {
+			return system.BuildCommitContent(commit, os.Stdin, os.Stdout, os.Stderr, buildStageCB)
+		}
 		return system.BuildCommit(commit, os.Stdin, os.Stdout, os.Stderr, buildStageCB)
 	}),
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -28,6 +28,8 @@ func init() {
 	describeDiffCmd.Flags().StringVar(&to, "to", "", "to commit")
 	describeLocalCmd.Flags().BoolVarP(&all, "all", "a", false, "describe all")
 
+	describeCommitCmd.Flags().BoolVarP(&content, "content", "c", false, "describe the modules impacted by the changes in commit")
+
 	describeCmd.PersistentFlags().BoolVar(&toJSON, "json", false, "format output as json")
 	describeCmd.PersistentFlags().BoolVar(&toGraph, "graph", false, "format output as dot graph")
 	describeCmd.AddCommand(describeCommitCmd)
@@ -159,6 +161,9 @@ var describeCommitCmd = &cobra.Command{
 	Long: `Describe all modules in the specified commit
 
 Commit SHA must be the complete 40 character SHA1 string.
+
+If --content flag is specified, this command will describe just the modules
+impacted by the specified commit.
 `,
 	RunE: buildHandler(func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -167,7 +172,17 @@ Commit SHA must be the complete 40 character SHA1 string.
 
 		commit := args[0]
 
-		m, err := system.ManifestByCommit(commit)
+		var (
+			m   *lib.Manifest
+			err error
+		)
+
+		if content {
+			m, err = system.ManifestByCommitContent(commit)
+		} else {
+			m, err = system.ManifestByCommit(commit)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,17 +10,18 @@ import (
 
 // Flags available to all commands.
 var (
-	in     string
-	src    string
-	dst    string
-	from   string
-	to     string
-	first  string
-	second string
-	kind   string
-	all    bool
-	debug  bool
-	system lib.System
+	in      string
+	src     string
+	dst     string
+	from    string
+	to      string
+	first   string
+	second  string
+	kind    string
+	all     bool
+	debug   bool
+	content bool
+	system  lib.System
 )
 
 func init() {

--- a/lib/build.go
+++ b/lib/build.go
@@ -62,6 +62,15 @@ func (s *stdSystem) BuildCommit(commit string, stdin io.Reader, stdout, stderr i
 	return build(s.Repo, m, stdin, stdout, stderr, callback, s.Log)
 }
 
+func (s *stdSystem) BuildCommitContent(commit string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) error {
+	m, err := s.ManifestByCommitContent(commit)
+	if err != nil {
+		return err
+	}
+
+	return build(s.Repo, m, stdin, stdout, stderr, callback, s.Log)
+}
+
 func (s *stdSystem) BuildWorkspace(stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) error {
 	m, err := s.ManifestByWorkspace()
 	if err != nil {

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -18,13 +18,20 @@ func (s *stdSystem) ManifestByPr(src, dst string) (*Manifest, error) {
 	return s.MB.ByPr(src, dst)
 }
 
-// ByCommit creates the manifest for the specified commit
 func (s *stdSystem) ManifestByCommit(sha string) (*Manifest, error) {
 	c, err := s.Repo.GetCommit(sha)
 	if err != nil {
 		return nil, err
 	}
 	return s.MB.ByCommit(c)
+}
+
+func (s *stdSystem) ManifestByCommitContent(sha string) (*Manifest, error) {
+	c, err := s.Repo.GetCommit(sha)
+	if err != nil {
+		return nil, err
+	}
+	return s.MB.ByCommitContent(c)
 }
 
 func (s *stdSystem) ManifestByBranch(name string) (*Manifest, error) {

--- a/lib/system.go
+++ b/lib/system.go
@@ -57,6 +57,11 @@ type Repo interface {
 	// DiffWorkspace gets the changes in current workspace.
 	// This should include untracked changes.
 	DiffWorkspace() ([]*DiffDelta, error)
+	// Changes returns a an array of DiffDelta objects representing the changes
+	// in the specified commit.
+	// Return an empty array if the specified commit is the first commit
+	// in the repo.
+	Changes(c Commit) ([]*DiffDelta, error)
 	// WalkBlobs invokes the callback for each blob reachable from the commit tree.
 	WalkBlobs(a Commit, callback BlobWalkCallback) error
 	// BlobContents of specified blob.
@@ -149,6 +154,9 @@ type ManifestBuilder interface {
 	ByPr(src, dst string) (*Manifest, error)
 	// ByCommit creates the manifest for the specified commit
 	ByCommit(sha Commit) (*Manifest, error)
+	// ByCommitContent creates the manifest for the content of the
+	// specified commit.
+	ByCommitContent(sha Commit) (*Manifest, error)
 	// ByBranch creates the manifest for the specified branch
 	ByBranch(name string) (*Manifest, error)
 	// ByCurrentBranch creates the manifest for the current branch
@@ -214,6 +222,9 @@ type System interface {
 	// BuildCommit builds specified commit.
 	BuildCommit(commit string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) error
 
+	// BuildCommitChanges builds the changes in specified commit
+	BuildCommitContent(commit string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) error
+
 	// BuildWorkspace builds the current workspace.
 	BuildWorkspace(stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) error
 
@@ -234,14 +245,17 @@ type System interface {
 	// between M and first and M and second.
 	IntersectionByBranch(first, second string) (Modules, error)
 
-	// ByDiff creates the manifest for diff between two commits
+	// ManifestByDiff creates the manifest for diff between two commits
 	ManifestByDiff(from, to string) (*Manifest, error)
 
-	// ByPr creates the manifest for diff between two branches
+	// ManifestByPr creates the manifest for diff between two branches
 	ManifestByPr(src, dst string) (*Manifest, error)
 
-	// ByCommit creates the manifest for the specified commit
+	// ManifestByCommit creates the manifest for the specified commit
 	ManifestByCommit(sha string) (*Manifest, error)
+
+	// ManifestByCommitContent creates the manifest for the content in specified commit
+	ManifestByCommitContent(sha string) (*Manifest, error)
 
 	// ByBranch creates the manifest for the specified branch
 	ManifestByBranch(name string) (*Manifest, error)


### PR DESCRIPTION
By default `buld|describe commit` commands considers all modules
found in the commit tree.

In this feature introduces a new flag for those commands called
`--content`.

When executed with `--content` flag, only the modules impacted
by the content of the commit are considered for the operation.

We compare the commit with its parent to detect which modules
have been affected. For merge commits with multiple parents,
we use the first parent (This requires verification before
we consider this feature as production ready).