### PR TITLE
Feature: Run mbt command from anywhere

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,10 @@ See help for individual commands for more information.
 			if err != nil {
 				return err
 			}
-			in = cwd
+			in, err = lib.GitRepoRoot(cwd)
+			if err != nil {
+				return err
+			}
 		}
 
 		level := lib.LogLevelNormal

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GitRepoRoot returns path to a git repo reachable from
+// the specified directory.
+// If the specified directory itself is not a git repo,
+// this function searches for it in the parent directory
+// path.
+func GitRepoRoot(dir string) (string, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	root, err := filepath.Abs("/")
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		test := filepath.Join(dir, ".git")
+		fi, err := os.Stat(test)
+		if err == nil && fi.IsDir() {
+			return dir, nil
+		}
+
+		if err != nil && !os.IsNotExist(err) {
+			return "", err
+		}
+
+		if dir == root {
+			return dir, nil
+		}
+
+		dir = filepath.Dir(dir)
+	}
+}

--- a/lib/utils_test.go
+++ b/lib/utils_test.go
@@ -1,0 +1,77 @@
+package lib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	repoDir, rootDir string
+)
+
+func init() {
+	var err error
+	repoDir, err = filepath.Abs(".tmp/repo")
+	if err != nil {
+		panic(err)
+	}
+
+	rootDir, err = filepath.Abs("/")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestGitRepoRootForPathWithoutAGitRepo(t *testing.T) {
+	path, err := GitRepoRoot("/tmp/this/does/not/exist")
+	assert.NoError(t, err)
+	assert.Equal(t, rootDir, path)
+}
+
+func TestGitRepoRootForRepoDir(t *testing.T) {
+	clean()
+	NewTestRepo(t, ".tmp/repo")
+	path, err := GitRepoRoot(".tmp/repo")
+	assert.NoError(t, err)
+	assert.Equal(t, repoDir, path)
+}
+
+func TestGitRepoRootForChildDir(t *testing.T) {
+	clean()
+	repo := NewTestRepo(t, ".tmp/repo")
+	check(t, repo.InitModule("app-a"))
+	check(t, repo.InitModule("a/b/c/app-b"))
+
+	path, err := GitRepoRoot(".tmp/repo/app-a")
+	assert.NoError(t, err)
+	assert.Equal(t, repoDir, path)
+
+	path, err = GitRepoRoot(".tmp/repo/a/b/c/app-b")
+	assert.NoError(t, err)
+	assert.Equal(t, repoDir, path)
+}
+
+func TestGitRepoRootForConflictingFileName(t *testing.T) {
+	clean()
+	repo := NewTestRepo(t, ".tmp/repo")
+	check(t, repo.WriteContent("a/b/.git", "hello"))
+
+	path, err := GitRepoRoot(".tmp/repo/a/b")
+	assert.NoError(t, err)
+	assert.Equal(t, repoDir, path)
+}
+
+func TestGitRepoRootForAbsPath(t *testing.T) {
+	clean()
+	repo := NewTestRepo(t, ".tmp/repo")
+	check(t, repo.InitModule("app-a"))
+
+	abs, err := filepath.Abs(".tmp/repo")
+	check(t, err)
+	path, err := GitRepoRoot(filepath.Join(abs, "app-a"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, repoDir, path)
+}


### PR DESCRIPTION
This feature introduces the ability to interrogate the file
system for git repository root (starting from cwd).

This behaviour is only activated when `--in` argument
is not specified.

Closes #45