### PR TITLE
Feature: Filter modules during local build/describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test: build_libgit2
 	go test -covermode=count ./trie
 	go test -covermode=count ./intercept
 	go test -covermode=count ./graph
+	go test -covermode=count ./utils
 	go test -covermode=count .
 
 .PHONY: showcover

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -18,6 +18,7 @@ func init() {
 	buildDiff.Flags().StringVar(&to, "to", "", "to commit")
 
 	buildLocal.Flags().BoolVarP(&all, "all", "a", false, "all modules")
+	buildLocal.Flags().StringVarP(&name, "name", "n", "", "build modules with a name that matches a subsequence filter. Multiple names can be specified as a comma separated string.")
 
 	buildCommit.Flags().BoolVarP(&content, "content", "c", false, "build the modules impacted by the content of the commit")
 
@@ -144,8 +145,8 @@ Local builds always uses a fixed version identifier - 'local'.
 Specify the --all flag to build all modules in current workspace.
 	`,
 	RunE: buildHandler(func(cmd *cobra.Command, args []string) error {
-		if all {
-			return summarise(system.BuildWorkspace(os.Stdin, os.Stdout, os.Stderr, buildStageCB))
+		if all || name != "" {
+			return summarise(system.BuildWorkspace(name, os.Stdin, os.Stdout, os.Stderr, buildStageCB))
 		}
 
 		return summarise(system.BuildWorkspaceChanges(os.Stdin, os.Stdout, os.Stderr, buildStageCB))

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -27,6 +27,7 @@ func init() {
 	describeDiffCmd.Flags().StringVar(&from, "from", "", "from commit")
 	describeDiffCmd.Flags().StringVar(&to, "to", "", "to commit")
 	describeLocalCmd.Flags().BoolVarP(&all, "all", "a", false, "describe all")
+	describeLocalCmd.Flags().StringVarP(&name, "name", "n", "", "describe modules with a name that matches a subsequence filter. Multiple names can be specified as a comma separated string.")
 
 	describeCommitCmd.Flags().BoolVarP(&content, "content", "c", false, "describe the modules impacted by the changes in commit")
 
@@ -114,8 +115,9 @@ This includes the modules in uncommitted changes.
 			err error
 		)
 
-		if all {
+		if all || name != "" {
 			m, err = system.ManifestByWorkspace()
+			m = m.FilterByName(name)
 		} else {
 			m, err = system.ManifestByWorkspaceChanges()
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	first   string
 	second  string
 	kind    string
+	name    string
 	all     bool
 	debug   bool
 	content bool

--- a/lib/build.go
+++ b/lib/build.go
@@ -71,10 +71,14 @@ func (s *stdSystem) BuildCommitContent(commit string, stdin io.Reader, stdout, s
 	return build(s.Repo, m, stdin, stdout, stderr, callback, s.Log)
 }
 
-func (s *stdSystem) BuildWorkspace(stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error) {
+func (s *stdSystem) BuildWorkspace(nameFilters string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error) {
 	m, err := s.ManifestByWorkspace()
 	if err != nil {
 		return nil, err
+	}
+
+	if nameFilters != "" {
+		m = m.FilterByName(nameFilters)
 	}
 
 	return buildDir(m, stdin, stdout, stderr, callback, s.Log)

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -1,5 +1,11 @@
 package lib
 
+import (
+	"strings"
+
+	"github.com/mbtproject/mbt/utils"
+)
+
 func (s *stdSystem) ManifestByDiff(from, to string) (*Manifest, error) {
 	f, err := s.Repo.GetCommit(from)
 	if err != nil {
@@ -48,4 +54,28 @@ func (s *stdSystem) ManifestByWorkspace() (*Manifest, error) {
 
 func (s *stdSystem) ManifestByWorkspaceChanges() (*Manifest, error) {
 	return s.MB.ByWorkspaceChanges()
+}
+
+// FilterByName reduces the modules in a Manifest to the
+// ones that are matching the terms specified in filter.
+// Multiple terms can be specified as a comma separated
+// string.
+// Comparison is a case insensitive subsequence comparison.
+func (m *Manifest) FilterByName(filter string) *Manifest {
+	filteredModules := make(Modules, 0)
+	filters := strings.Split(filter, ",")
+
+	for _, m := range m.Modules {
+		for _, f := range filters {
+			if utils.IsSubsequence(m.Name(), f, true) {
+				// We've got a match. Append it to the list
+				// and discard rest of the filters for this
+				// module.
+				filteredModules = append(filteredModules, m)
+				break
+			}
+		}
+	}
+
+	return &Manifest{Dir: m.Dir, Modules: filteredModules, Sha: m.Sha}
 }

--- a/lib/mbt_test.go
+++ b/lib/mbt_test.go
@@ -518,8 +518,8 @@ func (s *TestSystem) BuildCommitContent(commit string, stdin io.Reader, stdout, 
 
 }
 
-func (s *TestSystem) BuildWorkspace(stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error) {
-	ret := s.Interceptor.Call("BuildWorkspace", stdin, stdout, stderr, callback)
+func (s *TestSystem) BuildWorkspace(nameFilters string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error) {
+	ret := s.Interceptor.Call("BuildWorkspace", nameFilters, stdin, stdout, stderr, callback)
 	return sBuildSummary(ret[0]), sErr(ret[1])
 }
 

--- a/lib/system.go
+++ b/lib/system.go
@@ -246,7 +246,7 @@ type System interface {
 	BuildCommitContent(commit string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error)
 
 	// BuildWorkspace builds the current workspace.
-	BuildWorkspace(stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error)
+	BuildWorkspace(nameFilters string, stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error)
 
 	// BuildWorkspace builds changes in current workspace.
 	BuildWorkspaceChanges(stdin io.Reader, stdout, stderr io.Writer, callback BuildStageCallback) (*BuildSummary, error)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -60,6 +60,7 @@ go test ./dtrace -v -covermode=count
 go test ./trie -v -covermode=count
 go test ./intercept -v -covermode=count
 go test ./graph -v -covermode=count
+go test ./utils -v -covermode=count
 go test ./lib -v -covermode=count -coverprofile=coverage.out
 if [ ! -z $COVERALLS_TOKEN ] && [ -f ./coverage.out ]; then
   $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"strings"
+)
+
+// IsSubsequence takes two strings and returns true
+// if the second string is a subsequence of the first.
+// If ignoreCase is set, the comparison will be
+// case insensitive.
+// https://en.wikipedia.org/wiki/Subsequence
+func IsSubsequence(input, target string, ignoreCase bool) bool {
+	if ignoreCase {
+		input = strings.ToLower(input)
+		target = strings.ToLower(target)
+	}
+
+	idx := 0
+	targetArray := []rune(target)
+
+	for _, r := range input {
+		if len(targetArray) > idx && targetArray[idx] == r {
+			idx++
+		}
+	}
+
+	return idx == len(targetArray)
+}

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSubsequence(t *testing.T) {
+	assert.True(t, IsSubsequence("barry", "barry", false))
+	assert.True(t, IsSubsequence("barry", "arr", false))
+	assert.True(t, IsSubsequence("barry", "ary", false))
+	assert.True(t, IsSubsequence("barray allen", "aal", false))
+	assert.True(t, IsSubsequence("abc", "", false))
+	assert.True(t, IsSubsequence("", "", false))
+
+	assert.False(t, IsSubsequence("barray", "yr", false))
+	assert.False(t, IsSubsequence("barry", "barray a", false))
+	assert.False(t, IsSubsequence("barry", "bR", false))
+	assert.False(t, IsSubsequence("", "abc", false))
+
+	assert.True(t, IsSubsequence("barry", "barry", true))
+	assert.True(t, IsSubsequence("barry", "arr", true))
+	assert.True(t, IsSubsequence("barry", "ary", true))
+	assert.True(t, IsSubsequence("barray allen", "aal", true))
+	assert.True(t, IsSubsequence("abc", "", true))
+	assert.True(t, IsSubsequence("", "", true))
+	assert.True(t, IsSubsequence("barry", "bR", true))
+
+	assert.False(t, IsSubsequence("barray", "yr", true))
+	assert.False(t, IsSubsequence("barry", "barray a", true))
+	assert.False(t, IsSubsequence("", "abc", true))
+}


### PR DESCRIPTION
Specify a module name filter with `--name (-n for short)`
when running `local build|describe` commands.

Filters are subsequences and case insensitive.
Multiple filters can be specified by separating them
with a comma.

Closes #47