### PR TITLE
Fix: Detect local changes on root

### DIFF
--- a/lib/discover.go
+++ b/lib/discover.go
@@ -126,6 +126,15 @@ func (d *stdDiscover) ModulesInWorkspace() (Modules, error) {
 }
 
 func newModuleMetadata(dir string, hash string, spec *Spec) *moduleMetadata {
+	/*
+		Normalise the module dir. We always use paths
+		relative to the module root. Root is represented
+		as an empty string.
+	*/
+	if dir == "." {
+		dir = ""
+	}
+
 	return &moduleMetadata{
 		dir:  dir,
 		hash: hash,

--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -1139,3 +1139,16 @@ func TestCircularDependencyInWorkspace(t *testing.T) {
 	assert.EqualError(t, err, "Could not produce the module graph due to a cyclic dependency in path: app-a -> app-b -> app-a")
 	assert.Equal(t, ErrClassUser, (err.(*e.E)).Class())
 }
+
+func TestManifestByWorkspaceChangesForRootModule(t *testing.T) {
+	clean()
+	repo := NewTestRepo(t, ".tmp/repo")
+	check(t, repo.InitModuleWithOptions("", &Spec{Name: "root"}))
+
+	w := NewWorld(t, ".tmp/repo")
+	m, err := w.System.ManifestByWorkspaceChanges()
+	check(t, err)
+
+	assert.Len(t, m.Modules, 1)
+	assert.Equal(t, "root", m.Modules[0].Name())
+}


### PR DESCRIPTION
Running `mbt describe|build local` did not work
for root module.

Releated to #51