### PR TITLE
Fix: Prevent build|run-in commands when head is detached

### DIFF
--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -448,7 +448,7 @@ func TestDirtyWorkingDir(t *testing.T) {
 	buff := new(bytes.Buffer)
 	_, err := NewWorld(t, ".tmp/repo").System.BuildCurrentBranch(NoFilter, stdTestCmdOptions(buff))
 	assert.Error(t, err)
-	assert.Equal(t, "dirty working dir", err.Error())
+	assert.Equal(t, msgDirtyWorkingDir, err.Error())
 	assert.Equal(t, ErrClassUser, (err.(*e.E)).Class())
 }
 
@@ -587,7 +587,7 @@ func TestRestorationOfPristineWorkspace(t *testing.T) {
 	assert.Equal(t, "refs/heads/master", head.Name())
 }
 
-func TestRestorationOfPristineDetachedWorkspace(t *testing.T) {
+func TestBuildingDetachedHead(t *testing.T) {
 	clean()
 	repo := NewTestRepo(t, ".tmp/repo")
 	check(t, repo.InitModule("app-a"))
@@ -611,9 +611,13 @@ func TestRestorationOfPristineDetachedWorkspace(t *testing.T) {
 
 	w := NewWorld(t, ".tmp/repo")
 	buff := new(bytes.Buffer)
-	_, err := w.System.BuildBranch("feature", NoFilter, stdTestCmdOptions(buff))
-	check(t, err)
+	r, err := w.System.BuildBranch("feature", NoFilter, stdTestCmdOptions(buff))
 
+	assert.Nil(t, r)
+	assert.EqualError(t, err, msgDetachedHead)
+	assert.Equal(t, ErrClassUser, err.(*e.E).Class())
+
+	// Ensure that we don't touch this workspace
 	idx, err := repo.Repo.Index()
 	check(t, err)
 

--- a/lib/mbt_test.go
+++ b/lib/mbt_test.go
@@ -487,9 +487,9 @@ func (r *TestRepo) IsEmpty() (bool, error) {
 	return ret[0].(bool), sErr(ret[1])
 }
 
-func (r *TestRepo) IsDirtyWorkspace() (bool, error) {
-	ret := r.Interceptor.Call("IsDirtyWorkspace")
-	return ret[0].(bool), sErr(ret[1])
+func (r *TestRepo) EnsureSafeWorkspace() error {
+	ret := r.Interceptor.Call("EnsureSafeWorkspace")
+	return sErr(ret[0])
 }
 
 func (r *TestRepo) Checkout(commit Commit) (Reference, error) {

--- a/lib/repo_test.go
+++ b/lib/repo_test.go
@@ -76,10 +76,9 @@ func TestDirtyWorkspaceForUntracked(t *testing.T) {
 	check(t, repo.InitModule("app-a"))
 	check(t, repo.WriteContent("app-a/foo", "a"))
 
-	dirty, err := NewWorld(t, ".tmp/repo").Repo.IsDirtyWorkspace()
-	check(t, err)
+	err := NewWorld(t, ".tmp/repo").Repo.EnsureSafeWorkspace()
 
-	assert.True(t, dirty)
+	assert.EqualError(t, err, msgDirtyWorkingDir)
 }
 
 func TestDirtyWorkspaceForUpdates(t *testing.T) {
@@ -92,10 +91,9 @@ func TestDirtyWorkspaceForUpdates(t *testing.T) {
 
 	check(t, repo.WriteContent("app-a/foo", "b"))
 
-	dirty, err := NewWorld(t, ".tmp/repo").Repo.IsDirtyWorkspace()
-	check(t, err)
+	err := NewWorld(t, ".tmp/repo").Repo.EnsureSafeWorkspace()
 
-	assert.True(t, dirty)
+	assert.EqualError(t, err, msgDirtyWorkingDir)
 }
 
 func TestDirtyWorkspaceForRenames(t *testing.T) {
@@ -108,10 +106,9 @@ func TestDirtyWorkspaceForRenames(t *testing.T) {
 
 	check(t, repo.Rename("app-a/foo", "app-a/bar"))
 
-	dirty, err := NewWorld(t, ".tmp/repo").Repo.IsDirtyWorkspace()
-	check(t, err)
+	err := NewWorld(t, ".tmp/repo").Repo.EnsureSafeWorkspace()
 
-	assert.True(t, dirty)
+	assert.EqualError(t, err, msgDirtyWorkingDir)
 }
 
 func TestChangesOfFirstCommit(t *testing.T) {

--- a/lib/res.go
+++ b/lib/res.go
@@ -33,4 +33,6 @@ const (
 	msgFailedRestorationOfOldReference     = "Restoration of reference %v failed %v"
 	msgSuccessfulRestorationOfOldReference = "Successfully restored reference %v"
 	msgSuccessfulCheckout                  = "Successfully checked out commit %v"
+	msgDirtyWorkingDir                     = "Dirty working dir"
+	msgDetachedHead                        = "Head is currently detached"
 )

--- a/lib/run_in_test.go
+++ b/lib/run_in_test.go
@@ -75,7 +75,7 @@ func TestRunInDirtyWorkingDir(t *testing.T) {
 	result, err := w.System.RunInCurrentBranch("echo", NoFilter, stdTestCmdOptions(buff))
 
 	assert.Nil(t, result)
-	assert.EqualError(t, err, "dirty working dir")
+	assert.EqualError(t, err, msgDirtyWorkingDir)
 }
 
 func TestRunInBranch(t *testing.T) {

--- a/lib/system.go
+++ b/lib/system.go
@@ -102,8 +102,11 @@ type Repo interface {
 	CurrentBranchCommit() (Commit, error)
 	// IsEmpty informs if the current repository is empty or not.
 	IsEmpty() (bool, error)
-	// IsDirtyWorkspace returns true if the current workspace has uncommitted changes.
-	IsDirtyWorkspace() (bool, error)
+	// EnsureSafeWorkspace returns an error workspace is in a safe state
+	// for operations requiring a checkout.
+	// For example, in git repositories we consider uncommitted changes or
+	// a detached head is an unsafe state.
+	EnsureSafeWorkspace() error
 	// Checkout specified commit into workspace.
 	// Also returns a reference to the previous tree pointed by current workspace.
 	Checkout(commit Commit) (Reference, error)

--- a/lib/workspace_manager.go
+++ b/lib/workspace_manager.go
@@ -23,13 +23,9 @@ type stdWorkspaceManager struct {
 }
 
 func (w *stdWorkspaceManager) CheckoutAndRun(commit string, fn func() (interface{}, error)) (interface{}, error) {
-	dirty, err := w.Repo.IsDirtyWorkspace()
+	err := w.Repo.EnsureSafeWorkspace()
 	if err != nil {
 		return nil, err
-	}
-
-	if dirty {
-		return nil, e.NewError(ErrClassUser, "dirty working dir")
 	}
 
 	c, err := w.Repo.GetCommit(commit)


### PR DESCRIPTION
We currently don't support performing these operations when
the head is detached to keep workspace restoration logic
simple.

Assumption is that this is rare situation and we should
not complicate the code unless there's a good reason
for it.