### PR TITLE
Fix: Support builds when head is detached

### DIFF
--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -611,11 +611,8 @@ func TestBuildingDetachedHead(t *testing.T) {
 
 	w := NewWorld(t, ".tmp/repo")
 	buff := new(bytes.Buffer)
-	r, err := w.System.BuildBranch("feature", NoFilter, stdTestCmdOptions(buff))
-
-	assert.Nil(t, r)
-	assert.EqualError(t, err, msgDetachedHead)
-	assert.Equal(t, ErrClassUser, err.(*e.E).Class())
+	_, err := w.System.BuildBranch("feature", NoFilter, stdTestCmdOptions(buff))
+	check(t, err)
 
 	// Ensure that we don't touch this workspace
 	idx, err := repo.Repo.Index()

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -293,15 +293,6 @@ func (r *libgitRepo) IsEmpty() (bool, error) {
 }
 
 func (r *libgitRepo) EnsureSafeWorkspace() error {
-	detached, err := r.Repo.IsHeadDetached()
-	if err != nil {
-		return e.Wrap(ErrClassInternal, err)
-	}
-
-	if detached {
-		return e.NewError(ErrClassUser, msgDetachedHead)
-	}
-
 	status, err := r.Repo.StatusList(&git.StatusOptions{
 		Flags: git.StatusOptIncludeUntracked,
 	})


### PR DESCRIPTION
We added this restriction for 0.17.0. However,
in hindsight, this should have left alone because
build systems like Teamcity detach the head
before triggering the build for certain types of builds
(e.g. PRs)