### PR TITLE
Feature: Make a sorted modules list available for templates

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -15,6 +15,8 @@
         "fsutil",
         "Infof",
         "initialises",
+        "ishead",
+        "istail",
         "klass",
         "kvplist",
         "logrus",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,8 @@
     "errorz",
     "failf",
     "initialises",
+    "ishead",
+    "istail",
     "klass",
     "kvplist",
     "mbtproject",

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ As a simple but rather useless example of this can be illustrated with a templat
 as shown below.
 
 ```go
-{{ $module := range .Modules }}
+{{ $module := range .ModulesList }}
 {{ $module.Name }}
 {{ end }}
 ```
@@ -317,7 +317,7 @@ properties:
 available to templates via `.Properties` property as illustrated below.
 
 ```go
-{{ $module := range .Modules }}
+{{ $module := range .ModulesList }}
 {{ property $module "a" }} {{ property $module "b" }}
 {{ end }}
 ```


### PR DESCRIPTION
`.Modules` member passed into templates is a map. This makes
it difficult to have a stable template processing output.
If you require a stable list, use `.ModulesList` property.

Also Includes
- Hid the kvpSorter visibility.
  This does not have to be exported.