### PR TITLE
[fix] Avoid matching dirs and non spec files in local

### DIFF
--- a/lib/manifest_test.go
+++ b/lib/manifest_test.go
@@ -447,6 +447,30 @@ func TestManifestByLocalDirForAnEmptyRepo(t *testing.T) {
 	assert.Equal(t, "local", m.Modules[0].Version())
 }
 
+func TestManifestByLocalForFilesEndingWithSpecFileName(t *testing.T) {
+	clean()
+	repo := NewTestRepo(t, ".tmp/repo")
+
+	check(t, repo.WriteContent("dummy/interesting.mbt.yml", "hello"))
+
+	m, err := NewWorld(t, ".tmp/repo").System.ManifestByWorkspace()
+	check(t, err)
+
+	assert.Len(t, m.Modules, 0)
+}
+
+func TestManifestByLocalForDirsEndingWithSpecFileName(t *testing.T) {
+	clean()
+	repo := NewTestRepo(t, ".tmp/repo")
+
+	check(t, repo.WriteContent(".mbt.yml/hello", "world"))
+
+	m, err := NewWorld(t, ".tmp/repo").System.ManifestByWorkspace()
+	check(t, err)
+
+	assert.Len(t, m.Modules, 0)
+}
+
 func TestVersionOfLocalDirManifest(t *testing.T) {
 	// All modules should have the fixed version string "local" as
 	// for manifest derived from local directory.

--- a/lib/mbt_test.go
+++ b/lib/mbt_test.go
@@ -487,7 +487,7 @@ func (r *TestRepo) IsEmpty() (bool, error) {
 	return ret[0].(bool), sErr(ret[1])
 }
 
-func (r *TestRepo) FindAllFilesInWorkspace(pathSpec string) ([]string, error) {
+func (r *TestRepo) FindAllFilesInWorkspace(pathSpec []string) ([]string, error) {
 	ret := r.Interceptor.Call("FindAllFilesInWorkspace", pathSpec)
 	return ret[0].([]string), sErr(ret[1])
 }

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -292,11 +292,11 @@ func (r *libgitRepo) IsEmpty() (bool, error) {
 	return empty, nil
 }
 
-func (r *libgitRepo) FindAllFilesInWorkspace(pathSpec string) ([]string, error) {
+func (r *libgitRepo) FindAllFilesInWorkspace(pathSpec []string) ([]string, error) {
 	var configPaths []string
 	status, err := r.Repo.StatusList(&git.StatusOptions{
 		Flags:    git.StatusOptIncludeUntracked | git.StatusOptIncludeUnmodified | git.StatusOptRecurseUntrackedDirs,
-		Pathspec: []string{pathSpec},
+		Pathspec: pathSpec,
 	})
 
 	if err != nil {
@@ -310,8 +310,8 @@ func (r *libgitRepo) FindAllFilesInWorkspace(pathSpec string) ([]string, error) 
 		return nil, e.Wrap(ErrClassInternal, err)
 	}
 
+	r.Log.Debug("Discovered %v files matching the filter", count)
 	if count > 0 {
-		r.Log.Debug("Workspace has %v configs", count)
 		for c := 0; c < count; c++ {
 			entry, err := status.ByIndex(c)
 			if err != nil {
@@ -324,14 +324,13 @@ func (r *libgitRepo) FindAllFilesInWorkspace(pathSpec string) ([]string, error) 
 				if path == "" {
 					path = entry.HeadToIndex.NewFile.Path
 				}
-				r.Log.Debug("MBT config found: %v", path)
+				r.Log.Debug("Matching file detected: %v", path)
 				configPaths = append(configPaths, path)
 			}
 		}
-		return configPaths, nil
 	}
 
-	return nil, nil
+	return configPaths, nil
 }
 
 func (r *libgitRepo) EnsureSafeWorkspace() error {

--- a/lib/system.go
+++ b/lib/system.go
@@ -102,9 +102,8 @@ type Repo interface {
 	CurrentBranchCommit() (Commit, error)
 	// IsEmpty informs if the current repository is empty or not.
 	IsEmpty() (bool, error)
-	// FindAllFilesInWorkspace returns all files in repository matched to pathSpec, including untracked files
-	// Operation will works based on git status and respects git ignore
-	FindAllFilesInWorkspace(pathSpec string) ([]string, error)
+	// FindAllFilesInWorkspace returns all files in repository maching given pathSpec, including untracked files.
+	FindAllFilesInWorkspace(pathSpec []string) ([]string, error)
 	// EnsureSafeWorkspace returns an error workspace is in a safe state
 	// for operations requiring a checkout.
 	// For example, in git repositories we consider uncommitted changes or


### PR DESCRIPTION
- Changed `FindAllFilesInWorkspace` signature to accept an
  array of pathSpecs
- Added more test cases to cover the scenarios addressed
  in this change