### PR TITLE
[feat] Implement --dependents flag for describe command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,9 @@ var RootCmd = &cobra.Command{
 		if parent != nil && parent.Name() == "run-in" && command == "" {
 			return e.NewError(lib.ErrClassUser, "--command (-m) is not specified")
 		}
+		if parent != nil && parent.Name() == "describe" && dependents && name == "" {
+			return e.NewError(lib.ErrClassUser, "--dependents flag can only be specified with the --name (-n) flag")
+		}
 
 		level := lib.LogLevelNormal
 		if debug {

--- a/lib/build.go
+++ b/lib/build.go
@@ -32,7 +32,12 @@ func (s *stdSystem) BuildBranch(name string, filterOptions *FilterOptions, optio
 		return nil, err
 	}
 
-	return s.checkoutAndBuildManifest(m.ApplyFilters(filterOptions), options)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.checkoutAndBuildManifest(m, options)
 }
 
 func (s *stdSystem) BuildPr(src, dst string, options *CmdOptions) (*BuildSummary, error) {
@@ -59,7 +64,12 @@ func (s *stdSystem) BuildCurrentBranch(filterOptions *FilterOptions, options *Cm
 		return nil, err
 	}
 
-	return s.checkoutAndBuildManifest(m.ApplyFilters(filterOptions), options)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.checkoutAndBuildManifest(m, options)
 }
 
 func (s *stdSystem) BuildCommit(commit string, filterOptions *FilterOptions, options *CmdOptions) (*BuildSummary, error) {
@@ -68,7 +78,12 @@ func (s *stdSystem) BuildCommit(commit string, filterOptions *FilterOptions, opt
 		return nil, err
 	}
 
-	return s.checkoutAndBuildManifest(m.ApplyFilters(filterOptions), options)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.checkoutAndBuildManifest(m, options)
 }
 
 func (s *stdSystem) BuildCommitContent(commit string, options *CmdOptions) (*BuildSummary, error) {
@@ -86,7 +101,11 @@ func (s *stdSystem) BuildWorkspace(filterOptions *FilterOptions, options *CmdOpt
 		return nil, err
 	}
 
-	m = m.ApplyFilters(filterOptions)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return s.buildManifest(m, options)
 }
 

--- a/lib/dot_serializer.go
+++ b/lib/dot_serializer.go
@@ -40,3 +40,28 @@ func (mods Modules) SerializeAsDot() string {
   %s
 }`, strings.Join(paths, "\n  "))
 }
+
+// GroupedSerializeAsDot converts specified modules into a dot graph
+// that can be used for visualization with gv package.
+//
+// This variant groups impacted modules in red, while plotting
+// the rest of the graph in powderblue
+func (mods Modules) GroupedSerializeAsDot() string {
+	auxiliaryPaths := []string{}
+	impactedPaths := []string{}
+
+	for _, m := range mods {
+		impactedPaths = append(impactedPaths, fmt.Sprintf("\"%s\"", m.Name()))
+
+		for _, r := range m.Requires() {
+			auxiliaryPaths = append(auxiliaryPaths, fmt.Sprintf("\"%s\" -> \"%s\"", m.Name(), r.Name()))
+		}
+	}
+
+	return fmt.Sprintf(`digraph mbt {
+  node [shape=box fillcolor=red style=filled fontcolor=black];
+  %s
+  node [shape=box fillcolor=powderblue style=filled fontcolor=black];
+  %s
+}`, strings.Join(impactedPaths, "\n  "), strings.Join(auxiliaryPaths, "\n  "))
+}

--- a/lib/module.go
+++ b/lib/module.go
@@ -166,6 +166,12 @@ func (l Modules) expandRequiredByDependencies() (Modules, error) {
 	return r, nil
 }
 
+// expandRequiresDependencies takes a list of Modules and
+// returns a new list of Modules including the ones in their
+// requires (see below) dependency chain.
+// requires dependency
+// Module dependencies are described in two forms requires and requiredBy.
+// If A needs B, then, A requires B and B is requiredBy A.
 func (l Modules) expandRequiresDependencies() (Modules, error) {
 	g := make([]interface{}, 0, len(l))
 	for _, a := range l {

--- a/lib/run_in.go
+++ b/lib/run_in.go
@@ -27,7 +27,12 @@ func (s *stdSystem) RunInBranch(command, name string, filterOptions *FilterOptio
 		return nil, err
 	}
 
-	return s.checkoutAndRunManifest(command, m.ApplyFilters(filterOptions), options)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.checkoutAndRunManifest(command, m, options)
 }
 
 func (s *stdSystem) RunInPr(command, src, dst string, options *CmdOptions) (*RunResult, error) {
@@ -54,7 +59,12 @@ func (s *stdSystem) RunInCurrentBranch(command string, filterOptions *FilterOpti
 		return nil, err
 	}
 
-	return s.checkoutAndRunManifest(command, m.ApplyFilters(filterOptions), options)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.checkoutAndRunManifest(command, m, options)
 }
 
 func (s *stdSystem) RunInCommit(command, commit string, filterOptions *FilterOptions, options *CmdOptions) (*RunResult, error) {
@@ -63,7 +73,12 @@ func (s *stdSystem) RunInCommit(command, commit string, filterOptions *FilterOpt
 		return nil, err
 	}
 
-	return s.checkoutAndRunManifest(command, m.ApplyFilters(filterOptions), options)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.checkoutAndRunManifest(command, m, options)
 }
 
 func (s *stdSystem) RunInCommitContent(command, commit string, options *CmdOptions) (*RunResult, error) {
@@ -81,7 +96,11 @@ func (s *stdSystem) RunInWorkspace(command string, filterOptions *FilterOptions,
 		return nil, err
 	}
 
-	m = m.ApplyFilters(filterOptions)
+	m, err = m.ApplyFilters(filterOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return s.runManifest(command, m, options)
 }
 

--- a/lib/system.go
+++ b/lib/system.go
@@ -264,8 +264,9 @@ type CmdStageCallback func(mod *Module, s CmdStage, err error)
 
 // FilterOptions describe how to filter the modules in a manifest
 type FilterOptions struct {
-	Name  string
-	Fuzzy bool
+	Name       string
+	Fuzzy      bool
+	Dependents bool
 }
 
 // CmdOptions defines various options required by methods executing
@@ -450,6 +451,16 @@ func FuzzyFilter(name string) *FilterOptions {
 // ExactMatchFilter is a helper to create an exact match FilterOptions
 func ExactMatchFilter(name string) *FilterOptions {
 	return &FilterOptions{Name: name}
+}
+
+// FuzzyDependentsFilter is a helper to create a fuzzy match FilterOptions
+func FuzzyDependentsFilter(name string) *FilterOptions {
+	return &FilterOptions{Name: name, Fuzzy: true, Dependents: true}
+}
+
+// ExactMatchDependentsFilter is a helper to create an exact match FilterOptions
+func ExactMatchDependentsFilter(name string) *FilterOptions {
+	return &FilterOptions{Name: name, Dependents: true}
 }
 
 func initSystem(log Log, repo Repo, mb ManifestBuilder, discover Discover, reducer Reducer, workspaceManager WorkspaceManager, processManager ProcessManager) System {


### PR DESCRIPTION
This flag requires the --name flag to be used, given it
it'll will output the dependents on the modules
filtered on by the name flag.

Closes #28 