### PR TITLE
[fix] Correctly restore detached head after build or custom command

### DIFF
--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/libgit2/git2go"
+	git "github.com/libgit2/git2go"
 	"github.com/mbtproject/mbt/e"
 	"github.com/stretchr/testify/assert"
 )
@@ -657,17 +657,14 @@ func TestRestorationOfPristineWorkspace(t *testing.T) {
 	_, err := w.System.BuildBranch("feature", NoFilter, stdTestCmdOptions(buff))
 	check(t, err)
 
-	idx, err := repo.Repo.Index()
-	check(t, err)
-
-	diff, err := repo.Repo.DiffIndexToWorkdir(idx, &git.DiffOptions{
-		Flags: git.DiffIncludeUntracked | git.DiffRecurseUntracked,
+	status, err := repo.Repo.StatusList(&git.StatusOptions{
+		Flags: git.StatusOptIncludeUntracked,
 	})
 	check(t, err)
 
-	numDeltas, err := diff.NumDeltas()
+	statusEntriesCount, err := status.EntryCount()
 	check(t, err)
-	assert.Equal(t, 0, numDeltas)
+	assert.Equal(t, 0, statusEntriesCount)
 
 	head, err := repo.Repo.Head()
 	check(t, err)
@@ -701,18 +698,14 @@ func TestBuildingDetachedHead(t *testing.T) {
 	_, err := w.System.BuildBranch("feature", NoFilter, stdTestCmdOptions(buff))
 	check(t, err)
 
-	// Ensure that we don't touch this workspace
-	idx, err := repo.Repo.Index()
-	check(t, err)
-
-	diff, err := repo.Repo.DiffIndexToWorkdir(idx, &git.DiffOptions{
-		Flags: git.DiffIncludeUntracked | git.DiffRecurseUntracked,
+	status, err := repo.Repo.StatusList(&git.StatusOptions{
+		Flags: git.StatusOptIncludeUntracked,
 	})
 	check(t, err)
 
-	numDeltas, err := diff.NumDeltas()
+	statusEntriesCount, err := status.EntryCount()
 	check(t, err)
-	assert.Equal(t, 0, numDeltas)
+	assert.Equal(t, 0, statusEntriesCount)
 
 	detached, err := repo.Repo.IsHeadDetached()
 	check(t, err)

--- a/lib/system.go
+++ b/lib/system.go
@@ -63,6 +63,7 @@ type Commit interface {
 // this could be pointing to a branch, tag or commit.
 type Reference interface {
 	Name() string
+	SymbolicName() string
 }
 
 // Repo defines the set of interactions with the git repository.


### PR DESCRIPTION
Problem
When repository is in detached state, calling `.Name()` on
`Reference` returned by `Repository.Head()` returns `HEAD`.

When restoring this reference after the build, we pass this value to
`Repository.SetHead` method which basically peels current `HEAD`
to update the value. Since HEAD file is not updated, the diff between
the two trees appear in index as uncommitted.

Solution Overview
- `Reference` returned by `Checkout` has a new member called
`SymbolicName`.
- `SymbolicName` is set to reference name when repository is not in
detached state. Otherwise it has the default empty string.
- During restore, we rely on `SymbolicName` to determine whether to set
HEAD to a symbolic name or a commit SHA in detached mode.

Closes #122