### PR TITLE
Fix command indentation in module docs

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -44,10 +44,10 @@ build: Dictionary of build commands specific to a platform (optional)
 dependencies: An array of modules that this module's build depend on (optional)
 fileDependencies: An array of file names that this module's build depend on (optional)
 commands: Optional dictionary of custom commands (optional)
-  name: Custom command name (required)
-  cmd: Command name (required)
-  args: Array of arguments (optional)
-	os: Array of os identifiers where this command should run (optional)
+  name:
+    cmd: Command name (required)
+    args: Array of arguments (optional)
+    os: Array of os identifiers where this command should run (optional)
 properties: Custom dictionary to hold any module specific information (optional)
 {{c ""}}
 


### PR DESCRIPTION
I noticed when getting started that the indentation indicated in the docs is not quite correct, at least as I observed when testing. I think it's because the line for `os` had a tab, and the others had spaces?

In any case, I hope this is now the correct syntax for custom commands.

Let me know if I should also commit the results of running `make doc` - I did this and verified the output is correctly fixed, but there is a large diff, especially of whitespace, on files I shouldn't have affected.

Cheers!