### PR TITLE
fix bad version

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,6 +29,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show mbt version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("0.23.0")
+		fmt.Println("v0.24")
 	},
 }


### PR DESCRIPTION
This a very simple PR. Not sure of how you manage the versioning, but in the current release "v0.24" if you run `mbt version` the output is 0.23.0